### PR TITLE
Create SSH keys before joining IPA realm (#287)

### DIFF
--- a/snippets/freeipa_register.erb
+++ b/snippets/freeipa_register.erb
@@ -24,11 +24,15 @@ name: freeipa_register
 #
 #   freeipa_opts                Additional options to pass directly to installer
 #
+
 <% if @host.operatingsystem.family == 'Redhat' -%>
   <% if @host.operatingsystem.name == 'Fedora' -%>
     freeipa_client=freeipa-client
   <% else -%>
     freeipa_client=ipa-client
+  <% end -%>
+  <% if @host.operatingsystem.major.to_i > 6 -%>
+    /usr/sbin/sshd-keygen
   <% end -%>
 <% else -%>
   freeipa_client=freeipa-client


### PR DESCRIPTION
By default when joining a server to an ipa realm, the ssh public key gets uploaded, but since we are joining the realm before SSH has started and had a chance to create the host keys, running sshd-keygen before the ipa client installation puts keys into IPA and IPA can do the host key management.